### PR TITLE
Allow tools to build

### DIFF
--- a/llvm/tools/llc/CMakeLists.txt
+++ b/llvm/tools/llc/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LLVM_LINK_COMPONENTS
   LibFloor
   MC
   MIRParser
+  Passes
   Remarks
   ScalarOpts
   SelectionDAG


### PR DESCRIPTION
This allows the `LLVM_BUILD_TOOLS` CMake option to successfully build all of the LLVM 'tools' (including `metallic-dis`).